### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,16 @@
+{% extends template.self %}
+
+{% block style %}
+    {{ super() }}
+
+    {% if config.pluginsConfig['mermaid-compat'].theme %}
+        {% set mermaidAsset = 'gitbook-plugin-mermaid-compat/mermaid/mermaid.' %}
+        {% set mermaidTheme = mermaidAsset + config.pluginsConfig['mermaid-compat'].theme + '.css' %}
+        <link rel="stylesheet" href="{{ mermaidTheme|resolveAsset }}" />
+    {% endif %}
+{% endblock %}
+
+{% block javascript %}
+    {{ super() }}
+    <script src="{{ "gitbook-plugin-mermaid-compat/mermaid/mermaid.min.js"|resolveAsset }}"></script>
+{% endblock %}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,4 @@
 var mermaidRegex = /^```mermaid((.*[\r\n]+)+?)?```$/im;
-var pluginName = 'mermaid-compat';
-var mermainReleasedAssets = '/plugins/gitbook-plugin-mermaid-compat/mermaid/';
 
 function processMermaidBlockList(page) {
 
@@ -16,14 +14,6 @@ function processMermaidBlockList(page) {
   return page;
 }
 
-function addScript(filePath) {
-  return '<script src="' + filePath + '"></script>'
-}
-
-function addCss(filePath) {
-  return '<link rel="stylesheet" href="' + filePath + '"></link>'
-}
-
 module.exports = {
   website: {
     assets: './dist',
@@ -32,23 +22,7 @@ module.exports = {
     ],
     js: [
       'book/plugin.js'
-    ],
-    html: {
-      'head:end': function (options) {
-
-        var assetList = [
-          addScript(options.staticBase + mermainReleasedAssets + 'mermaid.min.js')
-        ];
-
-        var theme = (this.options.pluginsConfig[pluginName] || {}).theme;
-
-        if (theme) {
-          assetList.push(addCss(options.staticBase + mermainReleasedAssets + 'mermaid.' + theme + '.css'));
-        }
-
-        return assetList.join('');
-      }
-    }
+    ]
   },
   hooks: {
     'page:before': processMermaidBlockList


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the hooks used by your plugin will not be supported, since we are relying a lot more on the templating system to extend the books HTML.

The proposed PR has been tested with the new version and uses the templating system to include `mermaid.min.js` and the CSS theme extension.
Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

Don't forget to specify this in your `package.json`:

``` JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan
